### PR TITLE
Bugfix/32 memory leak

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,7 @@ services:
     volumes:
       - ./tests/resources/templates:/data/templates
       - ./tests/resources/report:/app/tests/resources/report
+    deploy:
+      resources:
+        limits:
+          memory: 1G


### PR DESCRIPTION
Tests will now show an error if they increased the RAM, this might still occur, the memory leak in production is fixed anyways.